### PR TITLE
Account for inheritance with custom type hint

### DIFF
--- a/src/Resources/templates/add.php.twig
+++ b/src/Resources/templates/add.php.twig
@@ -50,7 +50,15 @@
 {% endif %}
 {% if property.referencedProperty %}
     try {
-        $property = new \ReflectionProperty(${{ property.name | singularize }}, '{{ property.referencedProperty }}');
+{% if property.type == property.typeHint %}
+        $property = new \ReflectionProperty({{ property.type }}::class, '{{ property.referencedProperty }}');
+{% else %}
+        if (${{ property.name | singularize }} instanceof {{ property.type }}) {
+            $property = new \ReflectionProperty({{ property.type }}::class, '{{ property.referencedProperty }}');
+        } else {
+            $property = new \ReflectionProperty(${{ property.name | singularize }}, '{{ property.referencedProperty }}');
+        }
+{% endif %}
     } catch (\ReflectionException $e) {
         throw new \Hostnet\Component\AccessorGenerator\Exception\MissingPropertyException(
             $e->getMessage(),

--- a/test/Generator/PracticalVehicleOwnerTest.php
+++ b/test/Generator/PracticalVehicleOwnerTest.php
@@ -1,0 +1,67 @@
+<?php
+namespace Hostnet\Component\AccessorGenerator\Generator;
+
+use Hostnet\Component\AccessorGenerator\Generator\fixtures\Bicycle;
+use Hostnet\Component\AccessorGenerator\Generator\fixtures\Boat;
+use Hostnet\Component\AccessorGenerator\Generator\fixtures\Car;
+use Hostnet\Component\AccessorGenerator\Generator\fixtures\PracticalVehicleOwner;
+use Hostnet\Component\AccessorGenerator\Generator\fixtures\VehicleInterface;
+
+/**
+ * @covers \Hostnet\Component\AccessorGenerator\Generator\fixtures\Generated\PracticalVehicleOwnerMethodsTrait
+ */
+class PracticalVehicleOwnerTest extends \PHPUnit_Framework_TestCase
+{
+    public function testAddVehicle()
+    {
+        $boat = new Boat();
+        $car  = new Car();
+
+        $owner = new PracticalVehicleOwner();
+        $owner->addVehicle($boat)->addVehicle($car);
+
+        self::assertSame([$boat, $car], $owner->vehicles->toArray());
+    }
+
+    /**
+     * @expectedException \Hostnet\Component\AccessorGenerator\Exception\MissingPropertyException
+     */
+    public function testAddWrongVehicle()
+    {
+
+        $owner = new PracticalVehicleOwner();
+        $owner->addVehicle($this->prophesize(VehicleInterface::class)->reveal());
+    }
+
+    public function testAddCustomVehicle()
+    {
+        $owner   = new PracticalVehicleOwner();
+        $bicycle = new Bicycle();
+        $owner->addVehicle($bicycle)->addVehicle($bicycle);
+    }
+
+    /**
+     * @expectedException \BadMethodCallException
+     */
+    public function testAddVehicleTooManyArguments()
+    {
+        $car  = new Car();
+
+        $owner = new PracticalVehicleOwner();
+        $owner->addVehicle($car, $car);
+    }
+
+    /**
+     * @expectedException \LogicException
+     */
+    public function testAddVehicleToMultipleOwners()
+    {
+        $owner = new PracticalVehicleOwner();
+        $thief = new PracticalVehicleOwner();
+
+        $bicycle = new Bicycle();
+
+        $owner->addVehicle($bicycle);
+        $thief->addVehicle($bicycle);
+    }
+}

--- a/test/Generator/fixtures/AbstractVehicle.php
+++ b/test/Generator/fixtures/AbstractVehicle.php
@@ -1,0 +1,24 @@
+<?php
+namespace Hostnet\Component\AccessorGenerator\Generator\fixtures;
+
+use Doctrine\ORM\Mapping as ORM;
+use Hostnet\Component\AccessorGenerator\Annotation as AG;
+
+/**
+ * @ORM\Entity
+ * @ORM\DiscriminatorColumn(name="type", type="string")
+ * @ORM\DiscriminatorMap({"boat" = "Boat", "car" = "Car"})
+ */
+abstract class AbstractVehicle implements VehicleInterface
+{
+    /**
+     * @ORM\Id
+     * @ORM\Column
+     */
+    private $id;
+
+    /**
+     * @ORM\ManyToOne(targetEntity="PracticalVehicleOwner", inversedBy="vehicles")
+     */
+    private $owner;
+}

--- a/test/Generator/fixtures/Bicycle.php
+++ b/test/Generator/fixtures/Bicycle.php
@@ -1,0 +1,9 @@
+<?php
+namespace Hostnet\Component\AccessorGenerator\Generator\fixtures;
+
+use Doctrine\ORM\Mapping as ORM;
+use Hostnet\Component\AccessorGenerator\Annotation as AG;
+
+class Bicycle implements VehicleInterface {
+    private $owner;
+}

--- a/test/Generator/fixtures/Boat.php
+++ b/test/Generator/fixtures/Boat.php
@@ -1,0 +1,9 @@
+<?php
+namespace Hostnet\Component\AccessorGenerator\Generator\fixtures;
+
+use Doctrine\ORM\Mapping as ORM;
+use Hostnet\Component\AccessorGenerator\Annotation as AG;
+
+class Boat extends AbstractVehicle {
+
+}

--- a/test/Generator/fixtures/Car.php
+++ b/test/Generator/fixtures/Car.php
@@ -1,0 +1,9 @@
+<?php
+namespace Hostnet\Component\AccessorGenerator\Generator\fixtures;
+
+use Doctrine\ORM\Mapping as ORM;
+use Hostnet\Component\AccessorGenerator\Annotation as AG;
+
+class Car extends AbstractVehicle {
+
+}

--- a/test/Generator/fixtures/PracticalVehicleOwner.php
+++ b/test/Generator/fixtures/PracticalVehicleOwner.php
@@ -1,0 +1,31 @@
+<?php
+namespace Hostnet\Component\AccessorGenerator\Generator\fixtures;
+
+use Doctrine\ORM\Mapping as ORM;
+use Hostnet\Component\AccessorGenerator\Annotation as AG;
+
+class PracticalVehicleOwner
+{
+    use Generated\PracticalVehicleOwnerMethodsTrait;
+
+    /**
+     * @ORM\Id
+     * @ORM\Column
+     */
+    private $id;
+
+    /**
+     * @ORM\Column
+     */
+    private $name;
+
+    /**
+     * @ORM\OneToMany(targetEntity="AbstractVehicle", mappedBy="owner")
+     * @AG\Generate(
+     *     get="none",
+     *     remove="none",
+     *     type="\Hostnet\Component\AccessorGenerator\Generator\fixtures\VehicleInterface"
+     * )
+     */
+    public $vehicles;
+}

--- a/test/Generator/fixtures/VehicleInterface.php
+++ b/test/Generator/fixtures/VehicleInterface.php
@@ -1,0 +1,10 @@
+<?php
+namespace Hostnet\Component\AccessorGenerator\Generator\fixtures;
+
+use Doctrine\ORM\Mapping as ORM;
+use Hostnet\Component\AccessorGenerator\Annotation as AG;
+
+interface VehicleInterface
+{
+
+}

--- a/test/Generator/fixtures/expected/ActorMethodsTrait.php
+++ b/test/Generator/fixtures/expected/ActorMethodsTrait.php
@@ -64,7 +64,7 @@ trait ActorMethodsTrait
 
         $this->movies->add($movie);
         try {
-            $property = new \ReflectionProperty($movie, 'a');
+            $property = new \ReflectionProperty(\Hostnet\Component\AccessorGenerator\Generator\fixtures\Movie::class, 'a');
         } catch (\ReflectionException $e) {
             throw new \Hostnet\Component\AccessorGenerator\Exception\MissingPropertyException(
                 $e->getMessage(),

--- a/test/Generator/fixtures/expected/CategoryMethodsTrait.php
+++ b/test/Generator/fixtures/expected/CategoryMethodsTrait.php
@@ -65,7 +65,7 @@ trait CategoryMethodsTrait
 
         $this->children->add($child);
         try {
-            $property = new \ReflectionProperty($child, 'parent');
+            $property = new \ReflectionProperty(Category::class, 'parent');
         } catch (\ReflectionException $e) {
             throw new \Hostnet\Component\AccessorGenerator\Exception\MissingPropertyException(
                 $e->getMessage(),

--- a/test/Generator/fixtures/expected/ContactInfoMethodsTrait.php
+++ b/test/Generator/fixtures/expected/ContactInfoMethodsTrait.php
@@ -299,7 +299,7 @@ trait ContactInfoMethodsTrait
 
         $this->referenced_contacts->add($referenced_contact);
         try {
-            $property = new \ReflectionProperty($referenced_contact, 'referrer');
+            $property = new \ReflectionProperty(ContactInfo::class, 'referrer');
         } catch (\ReflectionException $e) {
             throw new \Hostnet\Component\AccessorGenerator\Exception\MissingPropertyException(
                 $e->getMessage(),
@@ -479,7 +479,7 @@ trait ContactInfoMethodsTrait
 
         $this->friends->add($friend);
         try {
-            $property = new \ReflectionProperty($friend, 'friended_by');
+            $property = new \ReflectionProperty(ContactInfo::class, 'friended_by');
         } catch (\ReflectionException $e) {
             throw new \Hostnet\Component\AccessorGenerator\Exception\MissingPropertyException(
                 $e->getMessage(),

--- a/test/Generator/fixtures/expected/MovieMethodsTrait.php
+++ b/test/Generator/fixtures/expected/MovieMethodsTrait.php
@@ -65,7 +65,7 @@ trait MovieMethodsTrait
 
         $this->a->add($a);
         try {
-            $property = new \ReflectionProperty($a, 'movies');
+            $property = new \ReflectionProperty(Actor::class, 'movies');
         } catch (\ReflectionException $e) {
             throw new \Hostnet\Component\AccessorGenerator\Exception\MissingPropertyException(
                 $e->getMessage(),

--- a/test/Generator/fixtures/expected/NodeMethodsTrait.php
+++ b/test/Generator/fixtures/expected/NodeMethodsTrait.php
@@ -64,7 +64,7 @@ trait NodeMethodsTrait
 
         $this->out->add($out);
         try {
-            $property = new \ReflectionProperty($out, 'in');
+            $property = new \ReflectionProperty(Node::class, 'in');
         } catch (\ReflectionException $e) {
             throw new \Hostnet\Component\AccessorGenerator\Exception\MissingPropertyException(
                 $e->getMessage(),

--- a/test/Generator/fixtures/expected/PracticalVehicleOwnerMethodsTrait.php
+++ b/test/Generator/fixtures/expected/PracticalVehicleOwnerMethodsTrait.php
@@ -1,0 +1,65 @@
+<?php
+// HEADER
+
+namespace Hostnet\Component\AccessorGenerator\Generator\fixtures\Generated;
+
+use Doctrine\ORM\Mapping as ORM;
+use Hostnet\Component\AccessorGenerator\Annotation as AG;
+use Hostnet\Component\AccessorGenerator\Generator\fixtures\AbstractVehicle;
+use Hostnet\Component\AccessorGenerator\Generator\fixtures\PracticalVehicleOwner;
+
+trait PracticalVehicleOwnerMethodsTrait
+{
+    /**
+     * Adds the given vehicle to this collection.
+     *
+     * @throws \BadMethodCallException if the number of arguments is not correct.
+     * @throws \LogicException         if a member was added that already exists within the collection.
+     * @throws \Hostnet\Component\AccessorGenerator\Exception\MissingPropertyException
+     *
+     * @param  \Hostnet\Component\AccessorGenerator\Generator\fixtures\VehicleInterface $vehicle
+     * @return $this|PracticalVehicleOwner
+     */
+    public function addVehicle(\Hostnet\Component\AccessorGenerator\Generator\fixtures\VehicleInterface $vehicle)
+    {
+        if (func_num_args() != 1) {
+            throw new \BadMethodCallException(
+                sprintf(
+                    'addVehicles() has one argument but %d given.',
+                    func_num_args()
+                )
+            );
+        }
+
+        /* @var $this->vehicles \Doctrine\Common\Collections\ArrayCollection */
+        if ($this->vehicles === null) {
+            $this->vehicles = new \Doctrine\Common\Collections\ArrayCollection();
+        } elseif ($this->vehicles->contains($vehicle)) {
+            return $this;
+        }
+
+        $this->vehicles->add($vehicle);
+        try {
+            if ($vehicle instanceof AbstractVehicle) {
+                $property = new \ReflectionProperty(AbstractVehicle::class, 'owner');
+            } else {
+                $property = new \ReflectionProperty($vehicle, 'owner');
+            }
+        } catch (\ReflectionException $e) {
+            throw new \Hostnet\Component\AccessorGenerator\Exception\MissingPropertyException(
+                $e->getMessage(),
+                $e->getCode(),
+                $e
+            );
+        }
+        $property->setAccessible(true);
+        $value = $property->getValue($vehicle);
+        if ($value && $value !== $this) {
+            throw new \LogicException('Vehicle can not be added to more than one PracticalVehicleOwner.');
+        }
+        $property->setValue($vehicle, $this);
+        $property->setAccessible(false);
+
+        return $this;
+    }
+}

--- a/test/Generator/fixtures/expected/ProductMethodsTrait.php
+++ b/test/Generator/fixtures/expected/ProductMethodsTrait.php
@@ -273,7 +273,7 @@ trait ProductMethodsTrait
         }
         $this->attributes->set($index, $attribute);
         try {
-            $property = new \ReflectionProperty($attribute, 'product');
+            $property = new \ReflectionProperty(Attribute::class, 'product');
         } catch (\ReflectionException $e) {
             throw new \Hostnet\Component\AccessorGenerator\Exception\MissingPropertyException(
                 $e->getMessage(),

--- a/test/Generator/fixtures/expected/SoftwareMethodsTrait.php
+++ b/test/Generator/fixtures/expected/SoftwareMethodsTrait.php
@@ -67,7 +67,11 @@ trait SoftwareMethodsTrait
 
         $this->features->add($feature);
         try {
-            $property = new \ReflectionProperty($feature, 'software');
+            if ($feature instanceof Feature) {
+                $property = new \ReflectionProperty(Feature::class, 'software');
+            } else {
+                $property = new \ReflectionProperty($feature, 'software');
+            }
         } catch (\ReflectionException $e) {
             throw new \Hostnet\Component\AccessorGenerator\Exception\MissingPropertyException(
                 $e->getMessage(),


### PR DESCRIPTION
When using a custom type hint on a collection and generate
an `add` method, reflection on the object will not be able
to access the private property of the parent class and when
using reflection on the class type of the relation an exception
will be thrown by PHP7.1 when the added object is of the
type hinted type and does not implement or extends the real
type, although the real type may implement the type hint type.

See `test/Generator/PracticalVehicleOwnerTest.php` for the
different cases and how they are handled.
