### PR TITLE
Made sure the KeyRegistry key array has a stable order

### DIFF
--- a/src/Generator/CodeGenerator.php
+++ b/src/Generator/CodeGenerator.php
@@ -408,6 +408,9 @@ class CodeGenerator implements CodeGeneratorInterface
             $filename = $path . DIRECTORY_SEPARATOR . $this->key_registry_class . '.php';
             $fs       = new Filesystem();
 
+            // make sure they are sorted
+            ksort($data['keys']);
+
             $data = $this->keys->render([
                 'namespace' => $data['namespace'] . '\\' . $this->namespace,
                 'keys'      => $data['keys'],


### PR DESCRIPTION
My unit tests were broken, this makes sure the order is always the same.