### PR TITLE
Made generator use the short names for integer and boolean

### DIFF
--- a/src/Generator/CodeGenerator.php
+++ b/src/Generator/CodeGenerator.php
@@ -269,7 +269,7 @@ class CodeGenerator implements CodeGeneratorInterface
      *
      * @param  string   $name
      * @param  string[] $imports
-     * @return boolean
+     * @return bool
      */
     private static function isAliased($name, array $imports)
     {

--- a/src/Resources/templates/get.php.twig
+++ b/src/Resources/templates/get.php.twig
@@ -18,7 +18,7 @@
  {% if property.collection -%}
  * @return {{ property.fullyQualifiedType }}[]|ImmutableCollection
  {% else -%}
- * @return {{ property.isComplexType ? property.typeHint : property.type}}{{ not property.willGenerateStrict ? '|null' }}
+ * @return {{ (property.isComplexType ? property.typeHint : property.type) | phptype }}{{ not property.willGenerateStrict ? '|null' }}
  {% endif -%}
  */
 {{ property.getGetVisibility() }} function {{ getter }}()

--- a/src/Resources/templates/set.php.twig
+++ b/src/Resources/templates/set.php.twig
@@ -24,7 +24,7 @@
  * @throws \LengthException if the length of the value is to long
  {% endif -%}
  *
- * @param  {{ property.typeHint }} ${{ property.name }}
+ * @param  {{ property.typeHint | phptype }} ${{ property.name }}
  {% if property.isFixedPointNumber -%}
  * @param  bool $round round the number fit in the precision and scale (round away from zero)
  {% endif -%}

--- a/src/Twig/CodeGenerationExtension.php
+++ b/src/Twig/CodeGenerationExtension.php
@@ -49,6 +49,15 @@ class CodeGenerationExtension extends \Twig_Extension
             new \Twig_SimpleFilter('singularize', function ($string) {
                 return Inflector::singularize($string);
             }),
+            new \Twig_SimpleFilter('phptype', function ($string) {
+                if ($string === 'integer') {
+                    return 'int';
+                }
+                if ($string === 'boolean') {
+                    return 'bool';
+                }
+                return $string;
+            }),
             new \Twig_SimpleFilter('twos_complement_min', function ($int) {
                 try {
                     return self::twosComplementMin($int);

--- a/test/Generator/CodeGeneratorTest.php
+++ b/test/Generator/CodeGeneratorTest.php
@@ -90,7 +90,11 @@ class CodeGeneratorTest extends \PHPUnit_Framework_TestCase
             // Assert we're not comparing the same file.
             self::assertNotEquals($expected_file->getPathname(), $actual_file_path);
             // Assert the contents is the expected contents.
-            self::assertEquals($expected_contents, $actual_contents);
+            self::assertEquals(
+                $expected_contents,
+                $actual_contents,
+                'Generated result does not match for for file ' . $expected_file
+            );
         }
     }
 

--- a/test/Generator/fixtures/expected/ConstantDefaultMethodsTrait.php
+++ b/test/Generator/fixtures/expected/ConstantDefaultMethodsTrait.php
@@ -16,7 +16,7 @@ trait ConstantDefaultMethodsTrait
      * @throws \BadMethodCallException
      * @throws \LogicException
      *
-     * @return integer
+     * @return int
      */
     public function getWeather()
     {
@@ -60,7 +60,7 @@ trait ConstantDefaultMethodsTrait
      * @throws \InvalidArgumentException if value is not of the right type
      * @throws \DomainException if the integer value is outside of the domain on this machine
      *
-     * @param  integer $weather
+     * @param  int $weather
      * @return $this|ConstantDefault
      */
     public function setWeather($weather = Weather::SUN)

--- a/test/Generator/fixtures/expected/ContactInfoMethodsTrait.php
+++ b/test/Generator/fixtures/expected/ContactInfoMethodsTrait.php
@@ -137,7 +137,7 @@ trait ContactInfoMethodsTrait
      *
      * @throws \BadMethodCallException
      *
-     * @return boolean|null
+     * @return bool|null
      */
     protected function isDeleted()
     {
@@ -163,7 +163,7 @@ trait ContactInfoMethodsTrait
      * @throws \BadMethodCallException if the number of arguments is not correct
      * @throws \InvalidArgumentException if value is not of the right type
      *
-     * @param  boolean $deleted
+     * @param  bool $deleted
      * @return $this|ContactInfo
      */
     public function setDeleted($deleted)
@@ -193,7 +193,7 @@ trait ContactInfoMethodsTrait
      *
      * @throws \BadMethodCallException
      *
-     * @return boolean|null
+     * @return bool|null
      */
     private function isSpendsLotsOfMoney()
     {
@@ -219,7 +219,7 @@ trait ContactInfoMethodsTrait
      * @throws \BadMethodCallException if the number of arguments is not correct
      * @throws \InvalidArgumentException if value is not of the right type
      *
-     * @param  boolean $spends_lots_of_money
+     * @param  bool $spends_lots_of_money
      * @return $this|ContactInfo
      */
     protected function setSpendsLotsOfMoney($spends_lots_of_money)

--- a/test/Generator/fixtures/expected/GenerateTypesMethodsTrait.php
+++ b/test/Generator/fixtures/expected/GenerateTypesMethodsTrait.php
@@ -14,7 +14,7 @@ trait GenerateTypesMethodsTrait
      * @throws \BadMethodCallException
      * @throws \LogicException
      *
-     * @return integer
+     * @return int
      */
     public function getInteger()
     {
@@ -58,7 +58,7 @@ trait GenerateTypesMethodsTrait
      * @throws \InvalidArgumentException if value is not of the right type
      * @throws \DomainException if the integer value is outside of the domain on this machine
      *
-     * @param  integer $integer
+     * @param  int $integer
      * @return $this|GenerateTypes
      */
     public function setInteger($integer)
@@ -230,7 +230,7 @@ trait GenerateTypesMethodsTrait
      * @throws \BadMethodCallException
      * @throws \LogicException
      *
-     * @return boolean
+     * @return bool
      */
     public function isBoolean()
     {
@@ -262,7 +262,7 @@ trait GenerateTypesMethodsTrait
      * @throws \BadMethodCallException if the number of arguments is not correct
      * @throws \InvalidArgumentException if value is not of the right type
      *
-     * @param  boolean $boolean
+     * @param  bool $boolean
      * @return $this|GenerateTypes
      */
     public function setBoolean($boolean)
@@ -293,7 +293,7 @@ trait GenerateTypesMethodsTrait
      * @throws \BadMethodCallException
      * @throws \LogicException
      *
-     * @return boolean
+     * @return bool
      */
     public function isThisBoolean()
     {
@@ -325,7 +325,7 @@ trait GenerateTypesMethodsTrait
      * @throws \BadMethodCallException if the number of arguments is not correct
      * @throws \InvalidArgumentException if value is not of the right type
      *
-     * @param  boolean $is_this_boolean
+     * @param  bool $is_this_boolean
      * @return $this|GenerateTypes
      */
     public function setIsThisBoolean($is_this_boolean)

--- a/test/Generator/fixtures/expected/NullableMethodsTrait.php
+++ b/test/Generator/fixtures/expected/NullableMethodsTrait.php
@@ -93,7 +93,7 @@ trait NullableMethodsTrait
      *
      * @throws \BadMethodCallException
      *
-     * @return integer
+     * @return int
      */
     public function getInt()
     {
@@ -131,7 +131,7 @@ trait NullableMethodsTrait
      * @throws \InvalidArgumentException if value is not of the right type
      * @throws \DomainException if the integer value is outside of the domain on this machine
      *
-     * @param  integer $int
+     * @param  int $int
      * @return $this|Nullable
      */
     public function setInt($int = null)
@@ -178,7 +178,7 @@ trait NullableMethodsTrait
      * @throws \InvalidArgumentException if value is not of the right type
      * @throws \DomainException if the integer value is outside of the domain on this machine
      *
-     * @param  integer $int_different
+     * @param  int $int_different
      * @return $this|Nullable
      */
     public function setIntDifferent($int_different = 2)

--- a/test/Generator/fixtures/expected/ProductMethodsTrait.php
+++ b/test/Generator/fixtures/expected/ProductMethodsTrait.php
@@ -16,7 +16,7 @@ trait ProductMethodsTrait
      *
      * @throws \BadMethodCallException
      *
-     * @return integer|null
+     * @return int|null
      */
     public function getId()
     {

--- a/test/Generator/fixtures/expected/TypesMethodsTrait.php
+++ b/test/Generator/fixtures/expected/TypesMethodsTrait.php
@@ -47,7 +47,7 @@ trait TypesMethodsTrait
      * @throws \BadMethodCallException
      * @throws \LogicException
      *
-     * @return integer
+     * @return int
      */
     public function getSmallint()
     {
@@ -91,7 +91,7 @@ trait TypesMethodsTrait
      * @throws \InvalidArgumentException if value is not of the right type
      * @throws \DomainException if the integer value is outside of the domain on this machine
      *
-     * @param  integer $smallint
+     * @param  int $smallint
      * @return $this|Types
      */
     public function setSmallint($smallint)
@@ -132,7 +132,7 @@ trait TypesMethodsTrait
      * @throws \BadMethodCallException
      * @throws \LogicException
      *
-     * @return integer
+     * @return int
      */
     public function getInteger()
     {
@@ -176,7 +176,7 @@ trait TypesMethodsTrait
      * @throws \InvalidArgumentException if value is not of the right type
      * @throws \DomainException if the integer value is outside of the domain on this machine
      *
-     * @param  integer $integer
+     * @param  int $integer
      * @return $this|Types
      */
     public function setInteger($integer)
@@ -217,7 +217,7 @@ trait TypesMethodsTrait
      * @throws \BadMethodCallException
      * @throws \LogicException
      *
-     * @return integer
+     * @return int
      */
     public function getBigint()
     {
@@ -265,7 +265,7 @@ trait TypesMethodsTrait
      * @throws \InvalidArgumentException if value is not of the right type
      * @throws \DomainException if the integer value is outside of the domain on this machine
      *
-     * @param  integer $bigint
+     * @param  int $bigint
      * @return $this|Types
      */
     public function setBigint($bigint)
@@ -754,7 +754,7 @@ trait TypesMethodsTrait
      * @throws \BadMethodCallException
      * @throws \LogicException
      *
-     * @return boolean
+     * @return bool
      */
     public function isBoolean()
     {
@@ -786,7 +786,7 @@ trait TypesMethodsTrait
      * @throws \BadMethodCallException if the number of arguments is not correct
      * @throws \InvalidArgumentException if value is not of the right type
      *
-     * @param  boolean $boolean
+     * @param  bool $boolean
      * @return $this|Types
      */
     public function setBoolean($boolean)
@@ -817,7 +817,7 @@ trait TypesMethodsTrait
      * @throws \BadMethodCallException
      * @throws \LogicException
      *
-     * @return boolean
+     * @return bool
      */
     public function isThisBoolean()
     {
@@ -849,7 +849,7 @@ trait TypesMethodsTrait
      * @throws \BadMethodCallException if the number of arguments is not correct
      * @throws \InvalidArgumentException if value is not of the right type
      *
-     * @param  boolean $is_this_boolean
+     * @param  bool $is_this_boolean
      * @return $this|Types
      */
     public function setIsThisBoolean($is_this_boolean)


### PR DESCRIPTION
Since php 7.0 we can typehint scalars. Since it then is also defined with the correct names of those types would be, the generator should use those for typehints.

I chose to use a twig filter since I do not mess with the internal `type` or `type_hint` fields in the `PropertyInformation` class. There is a lot depending on those names being a certain way.