### PR TITLE
change - allow encrypted fields to be type "text" as well as "string"

### DIFF
--- a/src/AnnotationProcessor/PropertyInformation.php
+++ b/src/AnnotationProcessor/PropertyInformation.php
@@ -241,7 +241,7 @@ class PropertyInformation implements PropertyInformationInterface
 
                 if ($annotation instanceof Column
                     && isset($annotation->type)
-                    && !in_array($annotation->type, ['string', 'text'])
+                    && ! in_array($annotation->type, ['string', 'text'])
                 ) {
                     $is_string = false;
                 }

--- a/src/AnnotationProcessor/PropertyInformation.php
+++ b/src/AnnotationProcessor/PropertyInformation.php
@@ -241,7 +241,7 @@ class PropertyInformation implements PropertyInformationInterface
 
                 if ($annotation instanceof Column
                     && isset($annotation->type)
-                    && $annotation->type !== 'string'
+                    && !in_array($annotation->type, ['string', 'text'])
                 ) {
                     $is_string = false;
                 }


### PR DESCRIPTION
I setup an entity which had a field with the type of "text" which I need to encrypt using this bundle.

Everything seemed to work as I expected (doctrine:schema:update --force created everything fine) but when I tried to run composer (I was requiring another bundle) I got the following error:
`[RuntimeException]`
`Property data in class AppBundle\Entity\Submission has an encryption_alias set, but is not declared as column type 'string' `

Changing the Annotation from `type="text"` to `type="string"` temporarily was enough to bypass this error but after speaking to @iltar he convinced my to try find a proper fix.

The fix is just to make sure we're checking again `"string"` and `"text"` which due to the code was easy to add.
Note: When testing the fix I used `composer dump-autoload` to get the error reliably.