### PR TITLE
Allow enumerator generation to work outside collection properties.

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,7 +358,7 @@ $task->getMyParams()->hasClientId();       // From MyTaskParamNames
 $task->getBetterParams()->setFoobar(1234); // From BetterParamNames
 ```
 
-### Separated enumerator accessor generator
+### Separated enumerator accessor generation
 You can also define enumerators outside the `@Generate` annotation. If used in combination with the `entity-plugin-lib`,
 it is possible to define a `trait` that holds an enumerator property that refers to a collection on your entity.
 
@@ -378,10 +378,9 @@ trait TaskTrait
     private $some_extra_params;
 }
 ```
+The `name` setting refers to the ArrayCollection property that holds all parameters owned by that entity.
 
-The `name` setting refers to the arry collection property that holds all parameters in the entity.
-
-Once the code is generated, you can now invoke the enumerator like so:
+Once the code is generated, you can now invoke the enumerator like any other:
 ```php
 <?php
 
@@ -393,4 +392,23 @@ $task->getMyParams();
 $task->getBetterParams();
 ```
 
-Make sure to include the trait `Generated\TaskTrait` - or whatever name your entity has - in the task entity to make this work.
+Make sure to include the trait `Generated\TaskTrait` - or whatever name your entity has - in the task entity to make
+this work. So,
+```php
+<?php
+class Task
+{
+    use Generated\TaskMethodsTrait;
+}
+```
+becomes:
+
+```php
+<?php
+class Task
+{
+    use Generated\TaskTrait;
+    use Generated\TaskMethodsTrait;
+}
+```
+Please refer to the [entity-plugin-lib](https://github.com/hostnet/entity-plugin-lib) for more information.

--- a/src/Annotation/Enumerator.php
+++ b/src/Annotation/Enumerator.php
@@ -4,19 +4,38 @@ namespace Hostnet\Component\AccessorGenerator\Annotation;
 use Doctrine\Common\Annotations\Annotation\Enum;
 
 /**
- * @Annotation(target={"ANNOTATION"})
+ * @Annotation(target={"ANNOTATION", "PROPERTY"})
  */
 class Enumerator
 {
     /**
+     * References the Enum class for the parameter collection.
+     *
      * @var string
      */
     public $value;
 
     /**
+     * References the name of the property that holds the parameter collection.
+     *
      * @var string
      */
     public $name;
+
+    /**
+     * References the property to assign the enum accessor to.
+     *
+     * @var string
+     */
+    public $property;
+
+    /**
+     * Specifies the parameter entity that is used to instantiate new parameter instances.
+     * This information is only required if the Enumerator annotation is used outside the Generator annotation.
+     *
+     * @var string
+     */
+    public $type;
 
     /**
      * @return string
@@ -32,5 +51,21 @@ class Enumerator
     public function getEnumeratorClass()
     {
         return $this->value;
+    }
+
+    /**
+     * @return string
+     */
+    public function getPropertyName()
+    {
+        return $this->property;
+    }
+
+    /**
+     * @return string
+     */
+    public function getType()
+    {
+        return $this->type;
     }
 }

--- a/src/AnnotationProcessor/PropertyInformation.php
+++ b/src/AnnotationProcessor/PropertyInformation.php
@@ -77,6 +77,12 @@ class PropertyInformation implements PropertyInformationInterface
     private $unique = null;
 
     /**
+     * @see PropertyInformationInterface::isGenerator()
+     * @var bool
+     */
+    private $is_generator = false;
+
+    /**
      * @see PropertyInformationInterface::isFixedPointNumber()
      * @var bool
      */
@@ -572,6 +578,22 @@ class PropertyInformation implements PropertyInformationInterface
     }
 
     /**
+     * @see PropertyInformationInterface::isGenerator()
+     */
+    public function setIsGenerator($bool)
+    {
+        $this->is_generator = $bool;
+    }
+
+    /**
+     * @see PropertyInformationInterface::isGenerator()
+     */
+    public function isGenerator()
+    {
+        return $this->is_generator;
+    }
+
+    /**
      * @see PropertyInformationInterface::getReferencedProperty()
      *
      * return string
@@ -1013,11 +1035,11 @@ class PropertyInformation implements PropertyInformationInterface
     }
 
     /**
-     * @param string[] $enums_to_generate
+     * @param Enumerator $enumerator
      */
-    public function setEnumeratorsToGenerate(array $enums_to_generate)
+    public function addEnumeratorToGenerate(Enumerator $enumerator)
     {
-        $this->enums_to_generate = $enums_to_generate;
+        $this->enums_to_generate[] = $enumerator;
     }
 
     /**

--- a/src/AnnotationProcessor/PropertyInformationInterface.php
+++ b/src/AnnotationProcessor/PropertyInformationInterface.php
@@ -76,6 +76,13 @@ interface PropertyInformationInterface
     public function getTypeHint();
 
     /**
+     * Returns true if this property uses the @Generate annotation.
+     *
+     * @return bool
+     */
+    public function isGenerator();
+
+    /**
      * Returns the fully qualified name of the type, including the complete
      * namespace, prefixed with am additional namespace separator (\).
      *

--- a/src/Generator/CodeGenerator.php
+++ b/src/Generator/CodeGenerator.php
@@ -178,17 +178,10 @@ class CodeGenerator implements CodeGeneratorInterface
                     . $this->enum_name_suffix
                     . '.php';
 
-                // If the "Enumerator" annotation is used directly without the "Generator" annotation, the type
-                // information will be missing, since we don't know in which entity the trait is used.
-                if ($info->getType()) {
-                    $this->validateEnumEntity($info->getType());
-                } elseif (empty($enumerator->getType())) {
-                    throw new \LogicException(sprintf(
-                        'Enumerator annotation in %s::%s must specifiy a "type" that refers to the parameter entity.',
-                        $class->getFullyQualifiedClassName(),
-                        $info->getName()
-                    ));
+                if (empty($info->getType()) && ! empty($enumerator->getType())) {
+                    $info->setType($enumerator->getType());
                 }
+                $this->validateEnumEntity($info->getType());
 
                 $fs->mkdir($path);
                 $fs->dumpFile($filename, $this->enum_class_cache[$cache_id]);

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -79,7 +79,7 @@ class Plugin implements PluginInterface, EventSubscriberInterface
     {
         return [
             ScriptEvents::PRE_AUTOLOAD_DUMP  => ['onPreAutoloadDump', 20],
-            ScriptEvents::POST_AUTOLOAD_DUMP => ['onPostAutoloadDump', 20]
+            ScriptEvents::POST_AUTOLOAD_DUMP => ['onPostAutoloadDump', 5]
         ];
     }
 

--- a/src/Resources/templates/enum_get.php.twig
+++ b/src/Resources/templates/enum_get.php.twig
@@ -1,4 +1,6 @@
+{% if add_property %}
 private ${{ enum_property }};
+{% endif %}
 
 /**
  * Returns a parameter collection for {{ enum_class }}.
@@ -17,3 +19,4 @@ public function get{{ name }}()
 
     return $this->{{ enum_property }};
 }
+

--- a/test/Generator/CodeGeneratorTest.php
+++ b/test/Generator/CodeGeneratorTest.php
@@ -105,6 +105,9 @@ class CodeGeneratorTest extends \PHPUnit_Framework_TestCase
      */
     public function testGenerateAccessorsTypeUnknown()
     {
-        $this->getGenerator()->generateAccessors(new PropertyInformation(new ReflectionProperty('phpunit')));
+        $info = new PropertyInformation(new ReflectionProperty('phpunit'));
+        $info->setIsGenerator(true); // Default for all @Generate properties.
+
+        $this->getGenerator()->generateAccessors($info);
     }
 }

--- a/test/Generator/fixtures/Parameterized.php
+++ b/test/Generator/fixtures/Parameterized.php
@@ -26,10 +26,15 @@ class Parameterized
      * )
      *
      * @AG\Generate(enumerators={
-     *     @AG\Enumerator("\Hostnet\Component\AccessorGenerator\Generator\fixtures\ParamName", name="Params")
+     *     @AG\Enumerator("\Hostnet\Component\AccessorGenerator\Generator\fixtures\ParamName", property="params")
      * })
      */
     private $parameters;
+
+    /**
+     * @var ParamName
+     */
+    private $params;
 
     public function __construct()
     {

--- a/test/Generator/fixtures/expected/ParamNameEnum.php
+++ b/test/Generator/fixtures/expected/ParamNameEnum.php
@@ -1,5 +1,5 @@
 <?php
-// Generated at 2018-02-22 13:15:13 by hiedema on se18-03-73-40-f6-af
+// Generated at 2018-03-01 11:55:03 by hiedema on se18-03-73-40-f6-af
 
 namespace Hostnet\Component\AccessorGenerator\Generator\fixtures\Generated;
 

--- a/test/Generator/fixtures/expected/ParameterMethodsTrait.php
+++ b/test/Generator/fixtures/expected/ParameterMethodsTrait.php
@@ -1,5 +1,5 @@
 <?php
-// Generated at 2018-02-22 15:32:48 by hiedema on se18-03-73-40-f6-af
+// Generated at 2018-03-01 11:55:03 by hiedema on se18-03-73-40-f6-af
 
 namespace Hostnet\Component\AccessorGenerator\Generator\fixtures\Generated;
 

--- a/test/Generator/fixtures/expected/ParameterizedMethodsTrait.php
+++ b/test/Generator/fixtures/expected/ParameterizedMethodsTrait.php
@@ -1,5 +1,5 @@
 <?php
-// Generated at 2018-02-22 13:12:39 by hiedema on se18-03-73-40-f6-af
+// Generated at 2018-03-01 11:55:03 by hiedema on se18-03-73-40-f6-af
 
 namespace Hostnet\Component\AccessorGenerator\Generator\fixtures\Generated;
 
@@ -10,8 +10,7 @@ use Hostnet\Component\AccessorGenerator\Generator\fixtures\Parameterized;
 
 trait ParameterizedMethodsTrait
 {
-    private $params_instance;
-
+    
     /**
      * Returns a parameter collection for \Hostnet\Component\AccessorGenerator\Generator\fixtures\ParamName.
      *
@@ -19,14 +18,14 @@ trait ParameterizedMethodsTrait
      */
     public function getParams()
     {
-        if (! $this->params_instance) {
-            $this->params_instance = new \Hostnet\Component\AccessorGenerator\Generator\fixtures\Generated\ParamNameEnum(
+        if (! $this->params) {
+            $this->params = new \Hostnet\Component\AccessorGenerator\Generator\fixtures\Generated\ParamNameEnum(
                 $this->parameters,
                 $this,
                 \Hostnet\Component\AccessorGenerator\Generator\fixtures\Parameter::class
             );
         }
 
-        return $this->params_instance;
+        return $this->params;
     }
 }

--- a/test/PluginTest.php
+++ b/test/PluginTest.php
@@ -33,7 +33,7 @@ class PluginTest extends \PHPUnit_Framework_TestCase
         self::assertSame(
             [
                 ScriptEvents::PRE_AUTOLOAD_DUMP  => ['onPreAutoloadDump', 20 ],
-                ScriptEvents::POST_AUTOLOAD_DUMP => ['onPostAutoloadDump', 20 ]
+                ScriptEvents::POST_AUTOLOAD_DUMP => ['onPostAutoloadDump', 5 ]
             ],
             Plugin::getSubscribedEvents()
         );


### PR DESCRIPTION
This PR adds support for separated enumerator generation if combined with the `entity-plugin-lib`. This effectively allows you to define enumerator generators for one class in a Trait from a different package.

See updated readme.
