### PR TITLE
Fixed ArrayCollection -> Collection typehint

### DIFF
--- a/src/Resources/templates/enum_class.php.twig
+++ b/src/Resources/templates/enum_class.php.twig
@@ -3,7 +3,7 @@
 
 namespace {{ namespace }};
 
-use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
 use Doctrine\Common\Collections\Criteria;
 
 /**
@@ -16,11 +16,11 @@ class {{ class_name }}
     private $parameter_entity_class;
 
     /**
-     * @param ArrayCollection $collection
-     * @param Entity|*        $owning_entity
-     * @param string          $parameter_entity_class
+     * @param Collection $collection
+     * @param Entity|*   $owning_entity
+     * @param string     $parameter_entity_class
      */
-    public function __construct(ArrayCollection $collection, $owning_entity, string $parameter_entity_class)
+    public function __construct(Collection $collection, $owning_entity, string $parameter_entity_class)
     {
         $this->collection             = $collection;
         $this->owning_entity          = $owning_entity;

--- a/test/Generator/fixtures/expected/ParamNameEnum.php
+++ b/test/Generator/fixtures/expected/ParamNameEnum.php
@@ -1,9 +1,9 @@
 <?php
-// Generated at 2018-03-01 11:55:03 by hiedema on se18-03-73-40-f6-af
+// Generated at 2018-03-09 10:46:20 by hiedema on se18-03-73-40-f6-af
 
 namespace Hostnet\Component\AccessorGenerator\Generator\fixtures\Generated;
 
-use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
 use Doctrine\Common\Collections\Criteria;
 
 /**
@@ -16,11 +16,11 @@ class ParamNameEnum
     private $parameter_entity_class;
 
     /**
-     * @param ArrayCollection $collection
-     * @param Entity|*        $owning_entity
-     * @param string          $parameter_entity_class
+     * @param Collection $collection
+     * @param Entity|*   $owning_entity
+     * @param string     $parameter_entity_class
      */
-    public function __construct(ArrayCollection $collection, $owning_entity, string $parameter_entity_class)
+    public function __construct(Collection $collection, $owning_entity, string $parameter_entity_class)
     {
         $this->collection             = $collection;
         $this->owning_entity          = $owning_entity;

--- a/test/Generator/fixtures/expected/ParameterMethodsTrait.php
+++ b/test/Generator/fixtures/expected/ParameterMethodsTrait.php
@@ -1,5 +1,5 @@
 <?php
-// Generated at 2018-03-01 11:55:03 by hiedema on se18-03-73-40-f6-af
+// Generated at 2018-03-09 10:46:20 by hiedema on se18-03-73-40-f6-af
 
 namespace Hostnet\Component\AccessorGenerator\Generator\fixtures\Generated;
 

--- a/test/Generator/fixtures/expected/ParameterizedMethodsTrait.php
+++ b/test/Generator/fixtures/expected/ParameterizedMethodsTrait.php
@@ -1,5 +1,5 @@
 <?php
-// Generated at 2018-03-01 11:55:03 by hiedema on se18-03-73-40-f6-af
+// Generated at 2018-03-09 10:46:20 by hiedema on se18-03-73-40-f6-af
 
 namespace Hostnet\Component\AccessorGenerator\Generator\fixtures\Generated;
 


### PR DESCRIPTION
When an entity is first initialized, it is instantiating collections using `ArrayCollection`. However, when an existing entity is pulled from the database, doctrine hydrates it as `PersistentCollection`, which isn't a derivative from `ArrayCollection`. This causes errors for entities pulled from a repository.

This PR addresses that issue.
