### PR TITLE
Show a message if an enum accessor cannot be generated

### DIFF
--- a/src/Generator/Exception/ReferencedClassNotFoundException.php
+++ b/src/Generator/Exception/ReferencedClassNotFoundException.php
@@ -1,0 +1,10 @@
+<?php
+namespace Hostnet\Component\AccessorGenerator\Generator\Exception;
+
+/**
+ * Thrown when a class was referenced from an annotation but was not found.
+ * This usually means that a required package was not present or not required propertly through composer.
+ */
+class ReferencedClassNotFoundException extends \Exception
+{
+}

--- a/test/Generator/CodeGeneratorTest.php
+++ b/test/Generator/CodeGeneratorTest.php
@@ -1,6 +1,7 @@
 <?php
 namespace Hostnet\Component\AccessorGenerator\Generator;
 
+use Hostnet\Component\AccessorGenerator\Annotation\Enumerator;
 use Hostnet\Component\AccessorGenerator\AnnotationProcessor\PropertyInformation;
 use Hostnet\Component\AccessorGenerator\Generator\Exception\TypeUnknownException;
 use Hostnet\Component\AccessorGenerator\Reflection\ReflectionClass;
@@ -73,10 +74,10 @@ class CodeGeneratorTest extends \PHPUnit_Framework_TestCase
 
     private function compareExpectedToGeneratedFiles($inverse = false)
     {
-        $paths           = ['/expected', '/Generated'];
-        $paths           = $inverse ? array_reverse($paths) : $paths;
-        $finder          = new Finder();
-        $expected_files  = $finder->name('*.php')->in(__DIR__ . '/fixtures' . $paths[0])->getIterator();
+        $paths          = ['/expected', '/Generated'];
+        $paths          = $inverse ? array_reverse($paths) : $paths;
+        $finder         = new Finder();
+        $expected_files = $finder->name('*.php')->in(__DIR__ . '/fixtures' . $paths[0])->getIterator();
 
         foreach ($expected_files as $expected_file) {
             // Get the mirrored file.
@@ -109,5 +110,20 @@ class CodeGeneratorTest extends \PHPUnit_Framework_TestCase
         $info->setIsGenerator(true); // Default for all @Generate properties.
 
         $this->getGenerator()->generateAccessors($info);
+    }
+
+    /**
+     * @expectedException \Hostnet\Component\AccessorGenerator\Generator\Exception\ReferencedClassNotFoundException
+     * @expectedExceptionMessage "CodeGeneratorTest" was not generated because the enum class "\This\Does\Not\Exist"
+     */
+    public function testGenerateEnumeratorClassNotFound()
+    {
+        $enumerator        = new Enumerator();
+        $enumerator->value = "\\This\\Does\\Not\\Exist";
+
+        $class = new ReflectionClass(__FILE__);
+        $info  = new PropertyInformation(new ReflectionProperty('my_prop', null, null, null, $class));
+
+        $this->getGenerator()->generateEnumeratorAccessors($enumerator, $info);
     }
 }


### PR DESCRIPTION
Fixes an issue where the entire generator crashed under the following scenario:

When code is generated from a composer package that is using the `entity-plugin-lib` to inline behavior from other repositories, but this repository is not a mandatory dependency, the generator would crash entirely becuase the referenced classes may not always be present.

This PR will show a message (as verbose output) if a referenced class does not exist, rather than crashing completely.
