### PR TITLE
Added json type support.

### DIFF
--- a/src/AnnotationProcessor/DoctrineAnnotationProcessor.php
+++ b/src/AnnotationProcessor/DoctrineAnnotationProcessor.php
@@ -238,7 +238,7 @@ class DoctrineAnnotationProcessor implements AnnotationProcessorInterface
             return '\\' . \DateTime::class;
         }
 
-        if (in_array($type, [Type::SIMPLE_ARRAY, Type::JSON_ARRAY, Type::TARRAY, self::YAML_ARRAY], true)) {
+        if (in_array($type, [Type::SIMPLE_ARRAY, Type::JSON_ARRAY, Type::JSON, Type::TARRAY, self::YAML_ARRAY], true)) {
             return 'array';
         }
 

--- a/test/AnnotationProcessor/DoctrineAnnotationProcessorTest.php
+++ b/test/AnnotationProcessor/DoctrineAnnotationProcessorTest.php
@@ -271,6 +271,7 @@ class DoctrineAnnotationProcessorTest extends TestCase
             [DoctrineAnnotationProcessor::ZEROED_DATE_TIME, '\\DateTime'],
             ['array',      'array'],
             ['json_array', 'array'],
+            ['json',       'array'],
             ['object',     'object'],
             ['double',     null,  \DomainException::class],
             ['bool',       null,  \DomainException::class],


### PR DESCRIPTION
Since `json_array` is deprecated since `2.6`. (https://www.doctrine-project.org/projects/doctrine-dbal/en/latest/reference/types.html#json-array)