### PR TITLE
Fix: pass valid argument types to twig runtime errors

### DIFF
--- a/src/Twig/CodeGenerationExtension.php
+++ b/src/Twig/CodeGenerationExtension.php
@@ -69,21 +69,21 @@ class CodeGenerationExtension extends AbstractExtension
                 try {
                     return self::twosComplementMin($int);
                 } catch (\DomainException $e) {
-                    throw new RuntimeError($e->getMessage(), null, null, $e);
+                    throw new RuntimeError($e->getMessage(), -1, null, $e);
                 }
             }),
             new TwigFilter('twos_complement_max', function ($int) {
                 try {
                     return self::twosComplementMax($int);
                 } catch (\DomainException $e) {
-                    throw new RuntimeError($e->getMessage(), null, null, $e);
+                    throw new RuntimeError($e->getMessage(), -1, null, $e);
                 }
             }),
             new TwigFilter('decimal_right_shift', function ($input, $amount) {
                 try {
                     return self::decimalRightShift($input, $amount);
                 } catch (\InvalidArgumentException $e) {
-                    throw new RuntimeError($e->getMessage(), null, null, $e);
+                    throw new RuntimeError($e->getMessage(), -1, null, $e);
                 }
             }),
         ];


### PR DESCRIPTION
Fixes the build.

It used to [fail](https://travis-ci.org/hostnet/accessor-generator-plugin-lib/builds/517745907).
Now it [passes](https://travis-ci.org/hostnet/accessor-generator-plugin-lib/builds/517756887).

Reason: Twig's `Error` class takes as second parameter `int $lineno = -1`, while `null` was given.