### PR TITLE
Only search among aliases instead of all imports

### DIFF
--- a/src/Generator/CodeGenerator.php
+++ b/src/Generator/CodeGenerator.php
@@ -471,7 +471,8 @@ class CodeGenerator implements CodeGeneratorInterface
      */
     private static function isAliased($name, array $imports): bool
     {
-        $aliases = array_keys($imports);
+        // Imports with alias have the alias as key, otherwise it has a numerical index
+        $aliases = array_filter(array_keys($imports), 'is_string');
         foreach ($aliases as $alias) {
             if (strpos($name, $alias) === 0) {
                 return true;


### PR DESCRIPTION
Fixes deprecation notice:
Deprecation Notice: strpos(): Non-string needles will be interpreted as strings in the future. Use an explicit chr() call to preserve the current behavior in /vendor/hostnet/accessor-generator-plugin-lib/src/Generator/CodeGenerator.php:476
