### PR TITLE
Added twig/twig ^3.0 forward compatibility and removed ^1.38.1 support.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "doctrine/inflector":   "~1.1",
         "doctrine/orm":         "~2.4",
         "symfony/filesystem":   "^3.0.2|~2.5|^4.0",
-        "twig/twig":            "^2.7.1||^1.38.1"
+        "twig/twig":            "^2.7.1||^3.0"
     },
     "require-dev": {
         "composer/composer":  "^1.0.0",

--- a/src/Generator/CodeGenerator.php
+++ b/src/Generator/CodeGenerator.php
@@ -129,14 +129,14 @@ class CodeGenerator implements CodeGeneratorInterface
         $twig   = new Environment($loader);
         $twig->addExtension(new CodeGenerationExtension());
 
-        $this->get        = $twig->loadTemplate('get.php.twig');
-        $this->set        = $twig->loadTemplate('set.php.twig');
-        $this->add        = $twig->loadTemplate('add.php.twig');
-        $this->remove     = $twig->loadTemplate('remove.php.twig');
-        $this->trait      = $twig->loadTemplate('trait.php.twig');
-        $this->keys       = $twig->loadTemplate('keys.php.twig');
-        $this->enum_get   = $twig->loadTemplate('enum_get.php.twig');
-        $this->enum_class = $twig->loadTemplate('enum_class.php.twig');
+        $this->get        = $twig->load('get.php.twig');
+        $this->set        = $twig->load('set.php.twig');
+        $this->add        = $twig->load('add.php.twig');
+        $this->remove     = $twig->load('remove.php.twig');
+        $this->trait      = $twig->load('trait.php.twig');
+        $this->keys       = $twig->load('keys.php.twig');
+        $this->enum_get   = $twig->load('enum_get.php.twig');
+        $this->enum_class = $twig->load('enum_class.php.twig');
     }
 
     /**
@@ -241,7 +241,7 @@ class CodeGenerator implements CodeGeneratorInterface
         ]);
     }
 
-    private function getMetadataForClass(ReflectionClass $class)
+    private function getMetadataForClass(ReflectionClass $class): array
     {
         $cache_key = (string) $class->getFilename();
         if (isset($this->metadata_cache[$cache_key])) {

--- a/src/Resources/templates/trait.php.twig
+++ b/src/Resources/templates/trait.php.twig
@@ -4,7 +4,7 @@
 namespace {{ namespace }};
 
 {% for alias, use in uses %}
-use {{ use }}{% if alias and alias == 0 %} as {{ alias }}{% endif %};
+use {{ use }}{% if alias is string %} as {{ alias }}{% endif %};
 {% endfor %}
 
 trait {{ name }}

--- a/src/Twig/CodeGenerationExtension.php
+++ b/src/Twig/CodeGenerationExtension.php
@@ -10,6 +10,7 @@ use Doctrine\Common\Inflector\Inflector;
 use Twig\Error\RuntimeError;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFilter;
+use Twig\TwigTest;
 
 /**
  * Twig extension to have some filters and tags available to be able to write
@@ -85,6 +86,18 @@ class CodeGenerationExtension extends AbstractExtension
                 } catch (\InvalidArgumentException $e) {
                     throw new RuntimeError($e->getMessage(), -1, null, $e);
                 }
+            }),
+        ];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getTests()
+    {
+        return [
+            new TwigTest('string', function ($input) {
+                return is_string($input);
             }),
         ];
     }

--- a/test/Generator/CodeGeneratorTest.php
+++ b/test/Generator/CodeGeneratorTest.php
@@ -67,7 +67,7 @@ class CodeGeneratorTest extends TestCase
         $this->compareExpectedToGeneratedFiles(true);
     }
 
-    private function getGenerator()
+    private function getGenerator(): CodeGenerator
     {
         if ($this->generator === null) {
             $this->generator = new CodeGenerator();
@@ -99,7 +99,7 @@ class CodeGeneratorTest extends TestCase
             self::assertEquals(
                 $expected_contents,
                 $actual_contents,
-                'Generated result does not match for for file ' . $expected_file
+                'Generated result does not match for file ' . $expected_file
             );
         }
     }

--- a/test/Twig/CodeGenerationExtensionTest.php
+++ b/test/Twig/CodeGenerationExtensionTest.php
@@ -41,6 +41,7 @@ class CodeGenerationExtensionTest extends TestCase
             'perline_stars'       => " {% perline %}\n * {{data}} *\n{% endperline %}",
             'perline_indent'      => "    {% perline %}\n    {{data}}\n    {% endperline %}",
             'decimal_right_shift' => '{{ data | decimal_right_shift(amount) }}',
+            'string'              => '{% if data is string %}true{% else %}false{% endif %}',
         ]);
 
         $this->twig = new Environment($loader);
@@ -138,7 +139,7 @@ class CodeGenerationExtensionTest extends TestCase
      * ordered as an array of string tuples.
      * @return string[][]
      */
-    public function singularizeProvider()
+    public function singularizeProvider(): array
     {
          return [
             ['categoria', 'categorias'],
@@ -235,5 +236,21 @@ class CodeGenerationExtensionTest extends TestCase
             $output,
             $this->twig->render('decimal_right_shift', ['data' => $input, 'amount' => $amount])
         );
+    }
+
+    /**
+     * @dataProvider stringProvider
+     */
+    public function testString($input, $output): void
+    {
+        self::assertEquals($output, $this->twig->render('string', ['data' => $input]));
+    }
+
+    public function stringProvider(): array
+    {
+        return [
+            [1, 'false'],
+            ['ORM', 'true'],
+        ];
     }
 }


### PR DESCRIPTION
The `trait.php.twig` modification
```diff
 {% for alias, use in uses %}
-use {{ use }}{% if alias and alias == 0 %} as {{ alias }}{% endif %};
+use {{ use }}{% if alias is string %} as {{ alias }}{% endif %};
 {% endfor %}
```
is necessary for the following unit test failure.
```diff
--- Expected
+++ Actual

-use Doctrine\ORM\Mapping as ORM;\n
-use Hostnet\Component\AccessorGenerator\Annotation as AG;\n
+use Doctrine\ORM\Mapping;\n
+use Hostnet\Component\AccessorGenerator\Annotation;\n
 use Hostnet\Component\AccessorGenerator\Collection\ImmutableCollection;\n
```
The `uses` array looks as followed.
```
array(3) {
  ["ORM"]=>
  string(20) "Doctrine\ORM\Mapping"
  ["AG"]=>
  string(46) "Hostnet\Component\AccessorGenerator\Annotation"
  [0]=>
  string(66) "Hostnet\Component\AccessorGenerator\Generator\fixtures\Credentials"
}
```
A test to show why this magically worked before: `{% if "TEST" == 0 %}true{% else %}false{% endif %}`
twig/twig 2.12.3 output: true
twig/twig 3.0.1 output: false

Note: `[0]=>
  string(66) "Hostnet\Component\AccessorGenerator\Generator\fixtures\Credentials"` is not imported, because it is the class itself.