### PR TITLE
Removed reference to possibly undefined variable

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -155,14 +155,13 @@ class Plugin implements PluginInterface, EventSubscriberInterface
                     if ($this->io->isVerbose()) {
                         $this->io->write("    - " . $e->getMessage());
                     }
-                }
-
-                if (!$generated_enum_classes || !$this->io->isVeryVerbose()) {
                     continue;
                 }
 
-                foreach ($generated_enum_classes as $generated_enum_class) {
-                    $this->io->write("    - Generated enumerator accessor for <info>$generated_enum_class</info>");
+                if ($this->io->isVeryVerbose()) {
+                    foreach ($generated_enum_classes as $generated_enum_class) {
+                        $this->io->write("    - Generated enumerator accessor for <info>$generated_enum_class</info>");
+                    }
                 }
             }
         }


### PR DESCRIPTION
`$generated_enum_classes` can be undefined in the case of the caught exception. This triggers an error.