### PR TITLE
fixed strpos deprecations when checking for aliases in use statements

### DIFF
--- a/src/Generator/CodeGenerator.php
+++ b/src/Generator/CodeGenerator.php
@@ -471,7 +471,7 @@ class CodeGenerator implements CodeGeneratorInterface
      */
     private static function isAliased($name, array $imports): bool
     {
-        $aliases = array_keys($imports);
+        $aliases = array_filter(array_keys($imports), 'is_string');
         foreach ($aliases as $alias) {
             if (strpos($name, $alias) === 0) {
                 return true;


### PR DESCRIPTION
Using a non-string needle is deprecated since php 7.3.
The given imports are generated from the use statements.
However, only imports with an alias, has the alias as the key.
Other imports added to the array and got an automatically assigned key, which is an integer.