### PR TITLE
json_decode always expects a string

### DIFF
--- a/src/Resources/templates/enum_class.php.twig
+++ b/src/Resources/templates/enum_class.php.twig
@@ -45,7 +45,7 @@ class {{ class_name }}
         }
 
 {% if info.typeHint == "array" %}
-        if (null === ($result = json_decode($this->get{{ info.methodName }}EntityInstance()->getValue(), true))) {
+        if (null === ($result = json_decode((string) $this->get{{ info.methodName }}EntityInstance()->getValue(), true))) {
             throw new \RuntimeException(
                 'The value of parameter "{{ info.constName }}" could not be converted to a native array type.'
             );

--- a/test/Generator/fixtures/expected/ParamName2Enum.php
+++ b/test/Generator/fixtures/expected/ParamName2Enum.php
@@ -43,7 +43,7 @@ class ParamName2Enum
             ));
         }
 
-        if (null === ($result = json_decode($this->getSomeArrayEntityInstance()->getValue(), true))) {
+        if (null === ($result = json_decode((string) $this->getSomeArrayEntityInstance()->getValue(), true))) {
             throw new \RuntimeException(
                 'The value of parameter "A_SOME_ARRAY" could not be converted to a native array type.'
             );

--- a/test/Generator/fixtures/expected/ParamNameEnum.php
+++ b/test/Generator/fixtures/expected/ParamNameEnum.php
@@ -43,7 +43,7 @@ class ParamNameEnum
             ));
         }
 
-        if (null === ($result = json_decode($this->getSomeArrayEntityInstance()->getValue(), true))) {
+        if (null === ($result = json_decode((string) $this->getSomeArrayEntityInstance()->getValue(), true))) {
             throw new \RuntimeException(
                 'The value of parameter "A_SOME_ARRAY" could not be converted to a native array type.'
             );


### PR DESCRIPTION
Prevents phpstan errors by never passing null into json_decode.