### PR TITLE
fixed correct creations of import statements for Traits

### DIFF
--- a/src/Generator/CodeGenerator.php
+++ b/src/Generator/CodeGenerator.php
@@ -391,7 +391,7 @@ class CodeGenerator implements CodeGeneratorInterface
                 [
                     'namespace' => $class->getNamespace() . '\\' . $this->namespace,
                     'name'      => $class->getName() . $this->name_suffix,
-                    'uses'      => $this->getUniqueImports($imports),
+                    'uses'      => UniqueImports::filter($imports),
                     'methods'   => rtrim($code),
                     'username'  => get_current_user(),
                     'hostname'  => gethostname(),
@@ -650,47 +650,6 @@ class CodeGenerator implements CodeGeneratorInterface
         $this->key_registry_data = [];
 
         return true;
-    }
-
-    /**
-     * Make sure our use statements are sorted alphabetically and unique. The
-     * array_unique function can not be used because it does not take values
-     * with different array keys into account. This loop does exactly that.
-     * This is useful when a specific class name is imported and aliased as
-     * well.
-     *
-     * @param string[] $imports
-     * @return string[]
-     */
-    private function getUniqueImports(array $imports): array
-    {
-        uksort($imports, function ($a, $b) use ($imports) {
-            $alias_a = is_numeric($a) ? " as $a;" : '';
-            $alias_b = is_numeric($b) ? " as $b;" : '';
-
-            return strcmp($imports[$a] . $alias_a, $imports[$b] . $alias_b);
-        });
-
-        $unique_imports = [];
-        $next           = null;
-        do {
-            $key   = key($imports);
-            $value = current($imports);
-            $next  = next($imports);
-
-            if ($value === $next && $key === key($imports)) {
-                continue;
-            }
-
-            if ($key) {
-                $unique_imports[$key] = $value;
-                continue;
-            }
-
-            $unique_imports[] = $value;
-        } while ($next !== false);
-
-        return $unique_imports;
     }
 
     /**

--- a/src/Generator/UniqueImports.php
+++ b/src/Generator/UniqueImports.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * @copyright 2021-present Hostnet B.V.
+ */
+declare(strict_types=1);
+
+namespace Hostnet\Component\AccessorGenerator\Generator;
+
+/**
+ * @internal
+ */
+final class UniqueImports
+{
+    /**
+     * Make sure our use statements are sorted alphabetically and unique. The
+     * array_unique function can not be used because it does not take values
+     * with different array keys into account. This loop does exactly that.
+     * This is useful when a specific class name is imported and aliased as
+     * well.
+     *
+     * @param string[] $imports
+     * @return string[]
+     */
+    public static function filter(array $imports): array
+    {
+        uksort($imports, function ($a, $b) use ($imports) {
+            $alias_a = is_numeric($a) ? " as $a;" : '';
+            $alias_b = is_numeric($b) ? " as $b;" : '';
+
+            return strcmp($imports[$a] . $alias_a, $imports[$b] . $alias_b);
+        });
+
+        $unique_imports = [];
+        $next           = null;
+        do {
+            $key   = key($imports);
+            $value = current($imports);
+            $next  = next($imports);
+
+            if ($value !== $next || (is_string($key) && $key !== key($imports))) {
+                if (is_string($key)) {
+                    $unique_imports[$key] = $value;
+                } else {
+                    $unique_imports[] = $value;
+                }
+            }
+        } while ($next !== false);
+
+        return $unique_imports;
+    }
+}

--- a/test/Generator/UniqueImportsTest.php
+++ b/test/Generator/UniqueImportsTest.php
@@ -1,0 +1,98 @@
+<?php
+/**
+ * @copyright 2021-present Hostnet B.V.
+ */
+declare(strict_types=1);
+
+namespace Hostnet\Component\AccessorGenerator\Generator;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Hostnet\Component\AccessorGenerator\Generator\UniqueImports
+ */
+class UniqueImportsTest extends TestCase
+{
+    public function testFilterEmptySet(): void
+    {
+        self::assertEmpty(UniqueImports::filter([]));
+    }
+
+    public function testFilterSortedSet(): void
+    {
+        $sorted_set = [
+            'A',
+            'A\A',
+            'A\B',
+            'B',
+            'B\A',
+        ];
+
+        self::assertSame($sorted_set, UniqueImports::filter($sorted_set));
+    }
+
+    public function testFilterUnsortedSet(): void
+    {
+        self::assertSame(
+            [
+                'A',
+                'A\A',
+                'A\B',
+                'B',
+                'B\A',
+            ],
+            UniqueImports::filter(
+                [
+                    'B',
+                    'A\A',
+                    'B\A',
+                    'A',
+                    'A\B',
+                ]
+            )
+        );
+    }
+
+    public function testFilterDuplicatesSet(): void
+    {
+        self::assertEquals(
+            [
+                'A',
+                'A\A',
+                'B',
+            ],
+            UniqueImports::filter(
+                [
+                    'A\A',
+                    'B',
+                    'B',
+                    'A',
+                    'A\A',
+                    'B',
+                ]
+            )
+        );
+    }
+
+    public function testFilterDuplicatesWithDifferentKeysSet(): void
+    {
+        self::assertSame(
+            [
+                0         => 'A',
+                1         => 'A\A',
+                'alias_a' => 'B',
+                'alias_b' => 'B',
+                2         => 'B',
+            ],
+            UniqueImports::filter(
+                [
+                    2         => 'B',
+                    'alias_a' => 'B',
+                    1         => 'A',
+                    0         => 'A\A',
+                    'alias_b' => 'B',
+                ]
+            )
+        );
+    }
+}


### PR DESCRIPTION
Traits were on rare occasions generated with or duplicate use statements or with a missing use statement.

Missing use statements happened, cause of:

```php
if ($key) {
    $unique_imports[$key] = $value;
    continue;
}

$unique_imports[] = $value;
}
```

When the `$key` is `0`, the `$value` will be added at the end of the array, with the next numeric key available in the array. So, when the last numeric key was `2`, it will be added as `3`. When the next import statement is added, that has the `$key` `3`, then it will overwrite the previous use statement.

Changes:

- Extracted method to an internal class to make the code testable.
- Reverted most internal logic to before the change of 6d603176433ebb1f2c43c4fd4149cf91f15b1c7f
- Only reuse keys that are strings