### PR TITLE
Prevent deprecation warning

### DIFF
--- a/src/Collection/ImmutableCollection.php
+++ b/src/Collection/ImmutableCollection.php
@@ -265,10 +265,8 @@ class ImmutableCollection implements Collection, ConstCollectionInterface, Selec
 
     /**
      * {@inheritdoc}
-     *
-     * @return mixed
      */
-    public function offsetGet($offset)
+    public function offsetGet($offset): mixed
     {
         return $this->collection->offsetGet($offset);
     }


### PR DESCRIPTION
Prevent warnings like

Deprecated: Return type of Hostnet\Component\AccessorGenerator\Collection\ImmutableCollection::offsetGet($offset) should either be compatible with ArrayAccess::offsetGet(mixed $offset): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in