### PR TITLE
Fixed tag deprecation in perline node

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "doctrine/inflector":   "^2.0.8",
         "doctrine/orm":         "^2.17.2",
         "symfony/filesystem":   "^5.4||^6.0",
-        "twig/twig":            "^3.9.3"
+        "twig/twig":            "^3.14.2"
     },
     "require-dev": {
         "composer/composer":        "^2.0.0",

--- a/src/Twig/PerLineNode.php
+++ b/src/Twig/PerLineNode.php
@@ -33,19 +33,17 @@ class PerLineNode extends Node
     /**
      * Create new PerLineNode
      *
-     * @param Node       $lines
-     * @param string     $prefix
-     * @param string     $postfix
-     * @param int        $lineno
-     * @param string     $tag
+     * @param Node   $lines
+     * @param string $prefix
+     * @param string $postfix
+     * @param int    $lineno
      */
-    public function __construct(Node $lines, $prefix, $postfix, $lineno, $tag = 'perline')
+    public function __construct(Node $lines, $prefix, $postfix, $lineno)
     {
         parent::__construct(
             ['lines' => $lines],
             ['prefix' => $prefix, 'postfix' => $postfix],
-            $lineno,
-            $tag
+            $lineno
         );
     }
 

--- a/src/Twig/PerLineTokenParser.php
+++ b/src/Twig/PerLineTokenParser.php
@@ -82,7 +82,7 @@ class PerLineTokenParser extends AbstractTokenParser
         // tag. This is the case when the perline tags could be removed without
         // an effect in the generated code.
         if (count($body) === 0) {
-            return new PerLineNode($body, '', '', $lineno, $this->getTag());
+            return new PerLineNode($body, '', '', $lineno);
         }
 
         // Get all the nodes as array, because it will be modified.
@@ -114,6 +114,6 @@ class PerLineTokenParser extends AbstractTokenParser
         }
 
         // Return the new structured node.
-        return new PerLineNode($nodes, $prefix, $postfix, $lineno, $this->getTag());
+        return new PerLineNode($nodes, $prefix, $postfix, $lineno);
     }
 }


### PR DESCRIPTION
Tag name is no longer required, as it is auto filled in now.
Updated minimal twig version.